### PR TITLE
Hide tooltips via ESC key

### DIFF
--- a/dist/zebra_tooltips.src.js
+++ b/dist/zebra_tooltips.src.js
@@ -229,6 +229,13 @@
                             if (title) $(this).attr('title', title);
 
                         });
+                        
+                        // hide tooltip when ESC is pressed
+                        $element.on('keyup', function (e) {
+                            if (e.key === 'Escape') {
+                                _hide($element);
+                            }
+                        });
 
                         // initialize and cache tooltip data
                         $element.data('Zebra_Tooltip', $.extend({


### PR DESCRIPTION
Please excuse the hacky way I did this! I'm not super well versed in jQuery plugin development, nor am I very familiar with git, unfortunately. But this seems to work and solved my issue, so I figured I'd share in case it's useful. Added an option to hide tooltips via the ESC key. As I understand it this is a requirement for Success Criterion 1.4.13 of WACG 2.1, I needed this for an project. Feel free to accept, edit or reject, and thanks for the plugin!